### PR TITLE
Use pako.js instead of pako.min.js to fix text garbling by using deflate

### DIFF
--- a/index.html
+++ b/index.html
@@ -67,7 +67,7 @@
     <script defer src="node_modules/url-parse/dist/url-parse.min.js"></script>
 
     <!-- Pako (zlib) -->
-    <script defer src="node_modules/pako/dist/pako.min.js"></script>
+    <script defer src="node_modules/pako/dist/pako.js"></script>
 
     <!-- LZMA -->
     <script defer src="node_modules/lzma/src/lzma_worker-min.js"></script>

--- a/service-worker.js
+++ b/service-worker.js
@@ -49,7 +49,7 @@ const CACHE_FILE = [
   "bower_components/opal/opal/0.11.3/time.min.js",
   "bower_components/opal/opal/0.11.3/yaml.min.js",
   "node_modules/url-parse/dist/url-parse.min.js",
-  "node_modules/pako/dist/pako.min.js",
+  "node_modules/pako/dist/pako.js",
   "node_modules/lzma/src/lzma_worker-min.js",
   "node_modules/ace-builds/src-min-noconflict/ace.js",
   "node_modules/angular/angular.min.js",


### PR DESCRIPTION
## Fixed
* Use pako.js instead of pako.min.js to fix text garbling by using deflate

## Current Nipp
By reloading browser, Nipp has text garbling.

![nipp-garbling mp4 opt](https://user-images.githubusercontent.com/10933561/52951177-6b668c00-33c4-11e9-8b48-042ebfe20c94.gif)

## Fixed one by this PR

Here is fixed one by this PR.
![nipp-garbling-fixed mp4 opt](https://user-images.githubusercontent.com/10933561/52951193-7a4d3e80-33c4-11e9-9ccf-e6af794b70c3.gif)


## Detail of this text garbling problem
You can find detail in <https://github.com/nodeca/pako/issues/160>.
