### PR TITLE
Use circleci/node instead of library/node

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,6 @@ version: 2
 ANCHORS:
  node_steps: &node_steps
    steps:
-     - run: apk --no-cache add git
      - checkout
      - run: npm install
      # Check whether "run build" is successful
@@ -12,17 +11,17 @@ ANCHORS:
 jobs:
   node_10:
     docker:
-      - image: node:10-alpine 
+      - image: circleci/node:10
     <<: *node_steps
   
   node_8:
     docker:
-      - image: node:8-alpine 
+      - image: circleci/node:8
     <<: *node_steps
   
   node_6:
     docker:
-      - image: node:6-alpine 
+      - image: circleci/node:6
     <<: *node_steps
   
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ ANCHORS:
      - checkout
      - run: npm install
      # Check whether "run build" is successful
-     - run: npm run build -- --allow-root
+     - run: npm run build
 
 jobs:
   node_10:


### PR DESCRIPTION
## Summary
* Use circleci/node instead of library/node in CircleCI
* Remove `--allow-root` option from `npm run build` in CircleCI

The main purpose of this PR is to support auto-deploy to `gh-page` branch