### PR TITLE
Deploy GitHub page automatically in CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,4 +64,4 @@ workflows:
           filters:
             branches:
               only:
-                - gh-pages-deploy-test-branch
+                - master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,12 +23,39 @@ jobs:
     docker:
       - image: circleci/node:6
     <<: *node_steps
+
+  gh_page_deploy:
+    docker:
+      - image: circleci/node:10
+    environment:
+      GIT_AUTHOR_EMAIL: nwtgck.bee@gmail.com
+      GIT_AUTHOR_NAME: "Bee Bot"
+      GIT_URL: https://${GITHUB_TOKEN}@github.com/nwtgck/trans-docs.git
+    steps:
+      - checkout
+      # Setting to push as @bee-bot
+      - git remote set-url origin ${GIT_URL}
+      - run: npm install
+      - run: npm run deploy
   
 workflows:
   version: 2
   node_tests:
     jobs:
-      - node_10
-      - node_8
-      - node_6
- 
+      - node_10:
+          filters:
+            branches:
+              only: /.*/
+      - node_8:
+          filters:
+            branches:
+              only: /.*/
+      - node_6:
+          filters:
+            branches:
+              only: /.*/
+      - gh_page_deploy:
+          filters:
+            branches:
+              only:
+                - gh-pages-deploy-test-branch

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,7 +34,7 @@ jobs:
     steps:
       - checkout
       # Setting to push as @bee-bot
-      - git remote set-url origin ${GIT_URL}
+      - run: git remote set-url origin ${GIT_URL}
       - run: npm install
       - run: npm run deploy
   

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,11 +30,10 @@ jobs:
     environment:
       GIT_AUTHOR_EMAIL: nwtgck.bee@gmail.com
       GIT_AUTHOR_NAME: "Bee Bot"
-      GIT_URL: https://${GITHUB_TOKEN}@github.com/nwtgck/trans-docs.git
     steps:
       - checkout
       # Setting to push as @bee-bot
-      - run: git remote set-url origin ${GIT_URL}
+      - run: git remote set-url origin https://${GITHUB_TOKEN}@github.com/nwtgck/nipp.git
       - run: npm install
       - run: npm run deploy
   

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,6 +55,10 @@ workflows:
             branches:
               only: /.*/
       - gh_page_deploy:
+          requires:
+            - node_10
+            - node_8
+            - node_6
           filters:
             branches:
               only:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,7 +33,10 @@ jobs:
     steps:
       - checkout
       # Setting to push as @bee-bot
+      - run: git config user.email "$GIT_AUTHOR_EMAIL"
+      - run: git config user.name "$GIT_AUTHOR_NAME"
       - run: git remote set-url origin https://${GITHUB_TOKEN}@github.com/nwtgck/nipp.git
+
       - run: npm install
       - run: npm run deploy
   


### PR DESCRIPTION
## Summary
* Deploy GitHub page automatically in CircleCI

This PR enables auto deploy on GitHub Pages by CircleCI. Push to `master` triggers the deployment. The deploy commit is done by @bee-bot.